### PR TITLE
Fix infinite loop for cycles in pytrees

### DIFF
--- a/jax_dataclasses/_copy_and_mutate.py
+++ b/jax_dataclasses/_copy_and_mutate.py
@@ -20,11 +20,12 @@ def _mark_mutable(
 ) -> None:
     """Recursively freeze or unfreeze dataclasses in a structure.
     Currently only supports tuples, lists, dictionaries, dataclasses."""
-
-    if visited is not None and id(obj) in visited:
+    
+    if visited is None:
+    	visited = set()
+    elif id(obj) in visited:
         return
-
-    visited = {id(obj)} if visited is None else visited.union({id(obj)})
+    visited.add(id(obj))
 
     if isinstance(obj, (tuple, list)):
         for child in obj:

--- a/jax_dataclasses/_copy_and_mutate.py
+++ b/jax_dataclasses/_copy_and_mutate.py
@@ -24,8 +24,7 @@ def _mark_mutable(
     if visited is not None and id(obj) in visited:
         return
 
-    visited = visited if visited is not None else set()
-    visited.add(id(obj))
+    visited = {id(obj)} if visited is None else visited.union({id(obj)})
 
     if isinstance(obj, (tuple, list)):
         for child in obj:

--- a/jax_dataclasses/_copy_and_mutate.py
+++ b/jax_dataclasses/_copy_and_mutate.py
@@ -20,9 +20,9 @@ def _mark_mutable(
 ) -> None:
     """Recursively freeze or unfreeze dataclasses in a structure.
     Currently only supports tuples, lists, dictionaries, dataclasses."""
-    
+
     if visited is None:
-    	visited = set()
+        visited = set()
     elif id(obj) in visited:
         return
     visited.add(id(obj))

--- a/jax_dataclasses/_copy_and_mutate.py
+++ b/jax_dataclasses/_copy_and_mutate.py
@@ -1,7 +1,7 @@
 import contextlib
 import dataclasses
 import enum
-from typing import Any, ContextManager, TypeVar
+from typing import Any, ContextManager, Optional, Set, TypeVar
 
 import jax
 from jax import numpy as jnp
@@ -15,13 +15,16 @@ class _Mutability(enum.Enum):
     MUTABLE_NO_VALIDATION = enum.auto()
 
 
-def _mark_mutable(obj: Any, mutable: _Mutability, visited = set()) -> None:
+def _mark_mutable(
+    obj: Any, mutable: _Mutability, visited: Optional[Set[Any]] = None
+) -> None:
     """Recursively freeze or unfreeze dataclasses in a structure.
     Currently only supports tuples, lists, dictionaries, dataclasses."""
 
-    if id(obj) in visited:
+    if visited is not None and id(obj) in visited:
         return
 
+    visited = visited if visited is not None else set()
     visited.add(id(obj))
 
     if isinstance(obj, (tuple, list)):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 setup(
     name="jax_dataclasses",
-    version="1.2.1",
+    version="1.2.2",
     description="Dataclasses + JAX",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_copy_and_mutate.py
+++ b/tests/test_copy_and_mutate.py
@@ -62,22 +62,27 @@ def test_copy_and_mutate():
 
 
 def test_copy_and_mutate_static():
+    @dataclasses.dataclass
+    class Inner:
+        a: int
+        b: int
+
     @jdc.pytree_dataclass
     class Foo:
         arrays: Dict[str, jnp.ndarray]
-        flag: bool = jdc.static_field()
+        child: Inner = jdc.static_field()
 
-    obj = Foo(arrays={"x": onp.ones(3)}, flag=False)
+    obj = Foo(arrays={"x": onp.ones(3)}, child=Inner(1, 2))
 
     # Registered dataclasses are initially immutable
     with pytest.raises(dataclasses.FrozenInstanceError):
-        obj.flag = True
+        obj.child = Inner(5, 6)
 
-    assert not obj.flag
+    assert obj.child == Inner(1, 2)
 
     # But can be copied and mutated in a special context
     with jdc.copy_and_mutate(obj) as obj_updated:
-        obj_updated.flag = True
+        obj_updated.child = Inner(5, 6)
 
-    assert not obj.flag
-    assert obj_updated.flag
+    assert obj.child == Inner(1, 2)
+    assert obj_updated.child == Inner(5, 6)

--- a/tests/test_cycle.py
+++ b/tests/test_cycle.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from jax import numpy as jnp
+
+import jax_dataclasses as jdc
+
+
+def test_cycle():
+    @jdc.pytree_dataclass
+    class TreeNode:
+        content: jnp.ndarray
+        children: Tuple[TreeNode, ...]
+
+    a = TreeNode(content=jnp.zeros(3), children=())
+    b = TreeNode(content=jnp.ones(3), children=(a,))
+
+    # Not a cycle. OK!
+    with jdc.copy_and_mutate(b, validate=False) as b:
+        b.children = (a, a)
+
+    # Cycle. Ideally this should raise an error, but the way duplicate nodes in pytrees
+    # are possible makes robust cycle detection under linear space/time constraints a
+    # hassle. So instead we currently do nothing.
+    with jdc.copy_and_mutate(b, validate=False) as b:
+        b.children[0].children = (b,)


### PR DESCRIPTION
I have a rather big dataclass to describe a robot model, that includes a graph of links and a list of joints. Each node of the graph references the parent link and all the child links. Each joint object references its parent and child links.

When I try to `copy_and_mutate` any of these objects, maybe due to all this nesting, an infinite loop occurs. I suspect that the existing logic tries to unfreeze all the leafs of the pytree, but the high interconnection and the properties of mutable Python types lead to a never ending unfreezing process.

This PR addresses this edge case by storing the list of IDs of objects already unfreezed. It solves my problem, and it should not add any noticeable performance degradation.

cc @brentyi 