### PR TITLE
Add support for jaxtyping

### DIFF
--- a/jax_dataclasses/_enforced_annotations.py
+++ b/jax_dataclasses/_enforced_annotations.py
@@ -1,13 +1,18 @@
 import dataclasses
 from typing import Any, List, Optional, Tuple, _AnnotatedAlias
 
+try:
+    from jaxtyping.array_types import _MetaAbstractArray, _NamedVariadicDim
+except ImportError:
+    _MetaAbstractArray = type(None)
+    _NamedVariadicDim = type(None)
+
 from jax import numpy as jnp
 from typing_extensions import TypeGuard
 
 from ._get_type_hints import get_type_hints_partial
 
 ExpectedShape = Tuple[Any, ...]
-import jaxtyping.array_types
 
 
 def _is_expected_shape(shape: Any) -> TypeGuard[ExpectedShape]:
@@ -128,7 +133,7 @@ class EnforcedAnnotationsMixin:
                         assert (
                             batch_axes == field_batch_axes
                         ), f"Batch axis mismatch: {batch_axes} and {field_batch_axes}."
-            elif isinstance(type_hint, jaxtyping.array_types._MetaAbstractArray):
+            elif isinstance(type_hint, _MetaAbstractArray):
                 if type_hint.index_variadic == 0 and len(type_hint.dims) == 1:
                     assert isinstance(value, type_hint)
                     continue
@@ -139,9 +144,7 @@ class EnforcedAnnotationsMixin:
                         (type_hint,),
                         {
                             "index_variadic": 0,
-                            "dims": [
-                                jaxtyping.array_types._NamedVariadicDim(object(), False)
-                            ]
+                            "dims": [_NamedVariadicDim(object(), False)]
                             + type_hint.dims,
                         },
                     )

--- a/jax_dataclasses/_enforced_annotations.py
+++ b/jax_dataclasses/_enforced_annotations.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, _AnnotatedAlias
 
 from jax import numpy as jnp
 from typing_extensions import TypeGuard
@@ -7,6 +7,7 @@ from typing_extensions import TypeGuard
 from ._get_type_hints import get_type_hints_partial
 
 ExpectedShape = Tuple[Any, ...]
+import jaxtyping.array_types
 
 
 def _is_expected_shape(shape: Any) -> TypeGuard[ExpectedShape]:
@@ -92,39 +93,73 @@ class EnforcedAnnotationsMixin:
                     child_batch_axes_list.append(child_batch_axes)
                 continue
 
-            # Check for metadata from `typing.Annotated` value! Skip if no annotation.
-            if not hasattr(type_hint, "__metadata__"):
-                continue
-            metadata: Tuple[Any, ...] = type_hint.__metadata__
-            assert (
-                len(metadata) <= 2
-            ), "We expect <= 2 metadata items; only shape and dtype are expected."
+            if isinstance(type_hint, _AnnotatedAlias):
+                if not hasattr(type_hint, "__metadata__"):
+                    continue
+                metadata: Tuple[Any, ...] = type_hint.__metadata__
+                assert (
+                    len(metadata) <= 2
+                ), "We expect <= 2 metadata items; only shape and dtype are expected."
 
-            # Check data type.
-            metadata_dtype = tuple(filter(_is_dtype, metadata))
-            if len(metadata_dtype) > 0 and hasattr(value, "dtype"):
-                (dtype,) = metadata_dtype
-                assert jnp.issubdtype(
-                    value.dtype, dtype
-                ), f"Mismatched dtype, expected {dtype} but got {value.dtype}."
+                # Check data type.
+                metadata_dtype = tuple(filter(_is_dtype, metadata))
+                if len(metadata_dtype) > 0 and hasattr(value, "dtype"):
+                    (dtype,) = metadata_dtype
+                    assert jnp.issubdtype(
+                        value.dtype, dtype
+                    ), f"Mismatched dtype, expected {dtype} but got {value.dtype}."
 
-            # Shape checks.
-            metadata_shape = tuple(filter(_is_expected_shape, metadata))
-            shape: Optional[Tuple[int, ...]] = None
-            if isinstance(value, (int, float)):
-                shape = ()
-            elif hasattr(value, "shape"):
-                shape = value.shape
-            if len(metadata_shape) > 0 and shape is not None:
-                # Get expected shape, sans batch axes.
-                (expected_shape,) = metadata_shape
-                field_batch_axes = _check_batch_axes(shape, expected_shape)
+                # Shape checks.
+                metadata_shape = tuple(filter(_is_expected_shape, metadata))
+                shape: Optional[Tuple[int, ...]] = None
+                if isinstance(value, (int, float)):
+                    shape = ()
+                elif hasattr(value, "shape"):
+                    shape = value.shape
+                if len(metadata_shape) > 0 and shape is not None:
+                    # Get expected shape, sans batch axes.
+                    (expected_shape,) = metadata_shape
+                    field_batch_axes = _check_batch_axes_annotated(
+                        shape, expected_shape
+                    )
+                    if batch_axes is None:
+                        batch_axes = field_batch_axes
+                    else:
+                        assert (
+                            batch_axes == field_batch_axes
+                        ), f"Batch axis mismatch: {batch_axes} and {field_batch_axes}."
+            elif isinstance(type_hint, jaxtyping.array_types._MetaAbstractArray):
+                if type_hint.index_variadic == 0 and len(type_hint.dims) == 1:
+                    assert isinstance(value, type_hint)
+                    continue
+
+                if type_hint.index_variadic is None:
+                    batched_type_hint = type(
+                        f"Batch{type_hint.__name__}",
+                        (type_hint,),
+                        {
+                            "index_variadic": 0,
+                            "dims": [
+                                jaxtyping.array_types._NamedVariadicDim(object(), False)
+                            ]
+                            + type_hint.dims,
+                        },
+                    )
+                else:
+                    batched_type_hint = type_hint
+                assert isinstance(value, batched_type_hint)
+
+                field_batch_axes = _check_batch_axes_jaxtyping(
+                    value.shape, batched_type_hint
+                )
                 if batch_axes is None:
                     batch_axes = field_batch_axes
                 else:
                     assert (
                         batch_axes == field_batch_axes
                     ), f"Batch axis mismatch: {batch_axes} and {field_batch_axes}."
+            else:
+                continue
 
         # Check child batch axes: any batch axes present in the parent should be present
         # in the children as well.
@@ -149,7 +184,7 @@ class EnforcedAnnotationsMixin:
         return batch_axes
 
 
-def _check_batch_axes(
+def _check_batch_axes_annotated(
     shape: Tuple[int, ...],
     expected_shape: ExpectedShape,
 ) -> Tuple[int, ...]:
@@ -179,4 +214,18 @@ def _check_batch_axes(
     else:
         batch_axes = shape
 
+    return batch_axes
+
+
+def _check_batch_axes_jaxtyping(
+    shape: Tuple[int, ...],
+    expected_shape: ExpectedShape,
+) -> Tuple[int, ...]:
+    batch_index = expected_shape.index_variadic
+    prefix = batch_index
+    suffix = len(expected_shape.dims) - batch_index - 1
+    if suffix == 0:
+        batch_axes = shape[prefix:]
+    else:
+        batch_axes = shape[prefix:-suffix]
     return batch_axes

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
             "flax",  # Used for serialization tests.
             "pytest",
             "pytest-cov",
-        ]
+        ],
+        "typing": ["jaxtyping"],
     },
     classifiers=[
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ setup(
     extras_require={
         "testing": [
             "flax",  # Used for serialization tests.
+            "jaxtyping",
             "pytest",
             "pytest-cov",
-        ],
-        "typing": ["jaxtyping"],
+        ]
     },
     classifiers=[
         "Programming Language :: Python :: 3.7",

--- a/tests/test_annotated_arrays.py
+++ b/tests/test_annotated_arrays.py
@@ -4,6 +4,7 @@ import jax
 import numpy as onp
 import pytest
 from jax import numpy as jnp
+from jaxtyping import Float, Integer, Shaped
 from typing_extensions import Annotated
 
 import jax_dataclasses as jdc
@@ -24,6 +25,12 @@ class MnistStruct(jdc.EnforcedAnnotationsMixin):
 
 
 @jdc.pytree_dataclass
+class JaxTypingMnistStruct(jdc.EnforcedAnnotationsMixin):
+    image: Float[onp.ndarray, "28 28"]
+    label: Integer[onp.ndarray, "10"]
+
+
+@jdc.pytree_dataclass
 class MnistStructPartial(jdc.EnforcedAnnotationsMixin):
     image_shape_only: Annotated[
         onp.ndarray,
@@ -35,102 +42,123 @@ class MnistStructPartial(jdc.EnforcedAnnotationsMixin):
     ]
 
 
+@jdc.pytree_dataclass
+class JaxTypingMnistStructPartial(jdc.EnforcedAnnotationsMixin):
+    image_shape_only: Shaped[onp.ndarray, "28 28"]
+    label_dtype_only: Integer[onp.ndarray, "..."]
+
+
 def test_valid() -> None:
-    data = MnistStruct(
-        image=onp.zeros((28, 28), dtype=onp.float32),
-        label=onp.zeros((10,), dtype=onp.uint8),
-    )
-    assert data.get_batch_axes() == ()
+    for struct, partial_struct in (
+        (MnistStruct, MnistStructPartial),
+        (JaxTypingMnistStruct, JaxTypingMnistStructPartial),
+    ):
+        data = struct(
+            image=onp.zeros((28, 28), dtype=onp.float32),
+            label=onp.zeros((10,), dtype=onp.uint8),
+        )
+        assert data.get_batch_axes() == ()
 
-    data = MnistStruct(
-        image=onp.zeros((5, 28, 28), dtype=onp.float32),
-        label=onp.zeros((5, 10), dtype=onp.uint8),
-    )
-    assert data.get_batch_axes() == (5,)
+        data = struct(
+            image=onp.zeros((5, 28, 28), dtype=onp.float32),
+            label=onp.zeros((5, 10), dtype=onp.uint8),
+        )
+        assert data.get_batch_axes() == (5,)
 
-    data = MnistStruct(
-        image=onp.zeros((5, 7, 28, 28), dtype=onp.float32),
-        label=onp.zeros((5, 7, 10), dtype=onp.uint8),
-    )
-    assert data.get_batch_axes() == (5, 7)
+        data = struct(
+            image=onp.zeros((5, 7, 28, 28), dtype=onp.float32),
+            label=onp.zeros((5, 7, 10), dtype=onp.uint8),
+        )
+        assert data.get_batch_axes() == (5, 7)
 
-    data_partial = MnistStructPartial(
-        image_shape_only=onp.zeros((7, 28, 28), dtype=onp.float32),
-        label_dtype_only=onp.zeros((70), dtype=onp.int32),
-    )
-    assert data_partial.get_batch_axes() == (7,)
+        data_partial = partial_struct(
+            image_shape_only=onp.zeros((7, 28, 28), dtype=onp.float32),
+            label_dtype_only=onp.zeros((70), dtype=onp.int32),
+        )
+        assert data_partial.get_batch_axes() == (7,)
 
 
 def test_shape_mismatch() -> None:
-    with pytest.raises(AssertionError):
-        MnistStruct(
-            image=onp.zeros((7, 32, 32), dtype=onp.float32),
-            label=onp.zeros((7, 10), dtype=onp.uint8),
-        )
+    for struct, partial_struct in (
+        (MnistStruct, MnistStructPartial),
+        (JaxTypingMnistStruct, JaxTypingMnistStructPartial),
+    ):
+        with pytest.raises(AssertionError):
+            struct(
+                image=onp.zeros((7, 32, 32), dtype=onp.float32),
+                label=onp.zeros((7, 10), dtype=onp.uint8),
+            )
 
-    with pytest.raises(AssertionError):
-        MnistStructPartial(
-            image_shape_only=onp.zeros((7, 32, 32), dtype=onp.float32),
-            label_dtype_only=onp.zeros((7, 10), dtype=onp.uint8),
-        )
+        with pytest.raises(AssertionError):
+            partial_struct(
+                image_shape_only=onp.zeros((7, 32, 32), dtype=onp.float32),
+                label_dtype_only=onp.zeros((7, 10), dtype=onp.uint8),
+            )
 
 
 def test_batch_axis_mismatch() -> None:
-    with pytest.raises(AssertionError):
-        MnistStruct(
-            image=onp.zeros((5, 7, 28, 28), dtype=onp.float32),
-            label=onp.zeros((7, 10), dtype=onp.uint8),
-        )
+    for struct in (MnistStruct, JaxTypingMnistStruct):
+        with pytest.raises(AssertionError):
+            struct(
+                image=onp.zeros((5, 7, 28, 28), dtype=onp.float32),
+                label=onp.zeros((7, 10), dtype=onp.uint8),
+            )
 
 
 def test_dtype_mismatch() -> None:
-    with pytest.raises(AssertionError):
-        MnistStruct(
-            image=onp.zeros((7, 28, 28), dtype=onp.uint8),
-            label=onp.zeros((7, 10), dtype=onp.uint8),
-        )
+    for struct, partial_struct in (
+        (MnistStruct, MnistStructPartial),
+        (JaxTypingMnistStruct, JaxTypingMnistStructPartial),
+    ):
+        with pytest.raises(AssertionError):
+            struct(
+                image=onp.zeros((7, 28, 28), dtype=onp.uint8),
+                label=onp.zeros((7, 10), dtype=onp.uint8),
+            )
 
-    with pytest.raises(AssertionError):
-        MnistStructPartial(
-            image_shape_only=onp.zeros((7, 28, 28), dtype=onp.float32),
-            label_dtype_only=onp.zeros((7, 10), dtype=onp.float32),
-        )
+        with pytest.raises(AssertionError):
+            partial_struct(
+                image_shape_only=onp.zeros((7, 28, 28), dtype=onp.float32),
+                label_dtype_only=onp.zeros((7, 10), dtype=onp.float32),
+            )
 
 
 def test_nested() -> None:
-    @jdc.pytree_dataclass
-    class Parent(jdc.EnforcedAnnotationsMixin):
-        x: Annotated[onp.ndarray, jnp.floating, ()]
-        child: MnistStruct
+    for struct in (MnistStruct, JaxTypingMnistStruct):
 
-    # OK
-    assert Parent(
-        x=onp.zeros((7,), dtype=onp.float32),
-        child=MnistStruct(
-            image=onp.zeros((7, 28, 28), dtype=onp.float32),
-            label=onp.zeros((7, 10), dtype=onp.uint8),
-        ),
-    ).get_batch_axes() == (7,)
+        @jdc.pytree_dataclass
+        class Parent(jdc.EnforcedAnnotationsMixin):
+            x: Annotated[onp.ndarray, jnp.floating, ()]
+            child: struct
 
-    # Batch axis mismatch
-    with pytest.raises(AssertionError):
-        Parent(
-            x=onp.zeros((5,), dtype=onp.float32),
-            child=MnistStruct(
+        # OK
+        assert Parent(
+            x=onp.zeros((7,), dtype=onp.float32),
+            child=struct(
                 image=onp.zeros((7, 28, 28), dtype=onp.float32),
                 label=onp.zeros((7, 10), dtype=onp.uint8),
             ),
-        )
+        ).get_batch_axes() == (7,)
 
-    # Type error
-    with pytest.raises(AssertionError):
-        Parent(
-            x=onp.zeros((7,), dtype=onp.float32),
-            child=MnistStruct(
-                image=onp.zeros((7, 28, 28), dtype=onp.float32),
-                label=onp.zeros((7, 10), dtype=onp.float32),
-            ),
-        )
+        # Batch axis mismatch
+        with pytest.raises(AssertionError):
+            Parent(
+                x=onp.zeros((5,), dtype=onp.float32),
+                child=struct(
+                    image=onp.zeros((7, 28, 28), dtype=onp.float32),
+                    label=onp.zeros((7, 10), dtype=onp.uint8),
+                ),
+            )
+
+        # Type error
+        with pytest.raises(AssertionError):
+            Parent(
+                x=onp.zeros((7,), dtype=onp.float32),
+                child=struct(
+                    image=onp.zeros((7, 28, 28), dtype=onp.float32),
+                    label=onp.zeros((7, 10), dtype=onp.float32),
+                ),
+            )
 
 
 def test_scalar() -> None:
@@ -140,6 +168,13 @@ def test_scalar() -> None:
 
     assert ScalarContainer(scalar=5.0).get_batch_axes() == ()  # type: ignore
     assert ScalarContainer(scalar=onp.zeros((5,))).get_batch_axes() == (5,)
+
+    @jdc.pytree_dataclass
+    class JaxTypingScalarContainer(jdc.EnforcedAnnotationsMixin):
+        scalar: Float[onp.ndarray, ""]  # () => scalar shape
+
+    assert JaxTypingScalarContainer(scalar=onp.array(5.0)).get_batch_axes() == ()
+    assert JaxTypingScalarContainer(scalar=onp.zeros((5,))).get_batch_axes() == (5,)
 
 
 def test_grad() -> None:
@@ -173,6 +208,18 @@ def test_middle_batch_axes() -> None:
         Test(onp.zeros((2, 1, 2, 3, 5, 7, 9)))
     with pytest.raises(AssertionError):
         Test(onp.zeros((3, 1, 2, 3, 5, 7)))
+
+    @jdc.pytree_dataclass
+    class JaxTypingTest(jdc.EnforcedAnnotationsMixin):
+        a: Float[onp.ndarray, "3 ... 5 7 9"]
+
+    test = JaxTypingTest(onp.zeros((3, 1, 2, 3, 5, 7, 9)))
+    assert test.get_batch_axes() == (1, 2, 3)
+
+    with pytest.raises(AssertionError):
+        JaxTypingTest(onp.zeros((2, 1, 2, 3, 5, 7, 9)))
+    with pytest.raises(AssertionError):
+        JaxTypingTest(onp.zeros((3, 1, 2, 3, 5, 7)))
 
 
 # This test currently breaks -- shape assertions on instantiation makes it impossible to


### PR DESCRIPTION
This PR adds support for jaxtyping annotations preserving all the features and checks on tensor dimensions.

The PR doesn't update the README, since it could become messy very easily. I'll wait further indications to update the README.