### PR TITLE
Remove `abstracted_axes` in `jit` wrapper for newer JAX versions

### DIFF
--- a/jax_dataclasses/_jit.py
+++ b/jax_dataclasses/_jit.py
@@ -9,7 +9,6 @@ from ._get_type_hints import get_type_hints_partial
 
 CallableType = TypeVar("CallableType", bound=Callable)
 
-_JIT_PARAMS = set(inspect.signature(jax.jit).parameters)
 
 @overload
 def jit(
@@ -20,7 +19,6 @@ def jit(
     donate_argnums: Union[int, Sequence[int]] = (),
     inline: bool = False,
     keep_unused: bool = False,
-    abstracted_axes: Optional[Any] = None,
 ) -> CallableType: ...
 
 
@@ -33,7 +31,6 @@ def jit(
     donate_argnums: Union[int, Sequence[int]] = (),
     inline: bool = False,
     keep_unused: bool = False,
-    abstracted_axes: Optional[Any] = None,
 ) -> Callable[[CallableType], CallableType]: ...
 
 
@@ -45,7 +42,6 @@ def jit(
     donate_argnums: Union[int, Sequence[int]] = (),
     inline: bool = False,
     keep_unused: bool = False,
-    abstracted_axes: Optional[Any] = None,
 ) -> Union[CallableType, Callable[[CallableType], CallableType]]:
     """Light wrapper around `jax.jit`, with usability and type checking improvements.
 
@@ -87,16 +83,6 @@ def jit(
             inline=inline,
             keep_unused=keep_unused,
         )
-
-        if "abstracted_axes" in _JIT_PARAMS:
-            jit_kwargs["abstracted_axes"] = abstracted_axes
-        else:
-            if abstracted_axes is not None:
-                raise TypeError(
-                    "This JAX version does not support jax.jit(..., abstracted_axes=...). "
-                    "If you need shape polymorphism, use jax.export with symbolic shapes instead."
-                )
-
         return cast(CallableType, jax.jit(fun, **jit_kwargs))
 
     if fun is None:

--- a/jax_dataclasses/_jit.py
+++ b/jax_dataclasses/_jit.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Callable, Optional, Sequence, TypeVar, Union, cast, overload
+from typing import Callable, Optional, Sequence, TypeVar, Union, cast, overload
 
 import jax
 from jaxlib import xla_client as xc

--- a/jax_dataclasses/_jit.py
+++ b/jax_dataclasses/_jit.py
@@ -74,16 +74,19 @@ def jit(
                 else:
                     static_argnames.append(name)
 
-        jit_kwargs = dict(
-            static_argnums=static_argnums if len(static_argnums) > 0 else None,
-            static_argnames=static_argnames if len(static_argnames) else None,
-            device=device,
-            backend=backend,
-            donate_argnums=donate_argnums,
-            inline=inline,
-            keep_unused=keep_unused,
+        return cast(
+            CallableType,
+            jax.jit(
+                fun,
+                static_argnums=static_argnums if len(static_argnums) > 0 else None,
+                static_argnames=static_argnames if len(static_argnames) else None,
+                device=device,
+                backend=backend,
+                donate_argnums=donate_argnums,
+                inline=inline,
+                keep_unused=keep_unused,
+            ),
         )
-        return cast(CallableType, jax.jit(fun, **jit_kwargs))
 
     if fun is None:
         return wrap

--- a/jax_dataclasses/_jit.py
+++ b/jax_dataclasses/_jit.py
@@ -9,6 +9,7 @@ from ._get_type_hints import get_type_hints_partial
 
 CallableType = TypeVar("CallableType", bound=Callable)
 
+_JIT_PARAMS = set(inspect.signature(jax.jit).parameters)
 
 @overload
 def jit(
@@ -77,20 +78,26 @@ def jit(
                 else:
                     static_argnames.append(name)
 
-        return cast(
-            CallableType,
-            jax.jit(
-                fun,
-                static_argnums=static_argnums if len(static_argnums) > 0 else None,
-                static_argnames=static_argnames if len(static_argnames) > 0 else None,
-                device=device,
-                backend=backend,
-                donate_argnums=donate_argnums,
-                inline=inline,
-                keep_unused=keep_unused,
-                abstracted_axes=abstracted_axes,
-            ),
+        jit_kwargs = dict(
+            static_argnums=static_argnums if len(static_argnums) > 0 else None,
+            static_argnames=static_argnames if len(static_argnames) else None,
+            device=device,
+            backend=backend,
+            donate_argnums=donate_argnums,
+            inline=inline,
+            keep_unused=keep_unused,
         )
+
+        if "abstracted_axes" in _JIT_PARAMS:
+            jit_kwargs["abstracted_axes"] = abstracted_axes
+        else:
+            if abstracted_axes is not None:
+                raise TypeError(
+                    "This JAX version does not support jax.jit(..., abstracted_axes=...). "
+                    "If you need shape polymorphism, use jax.export with symbolic shapes instead."
+                )
+
+        return cast(CallableType, jax.jit(fun, **jit_kwargs))
 
     if fun is None:
         return wrap


### PR DESCRIPTION
Newer JAX versions removed `abstracted_axes` from `jax.jit`; this change conditionally forwards it when available and points users to `jax.export` for shape polymorphism. 

See https://github.com/jax-ml/jax/pull/33565